### PR TITLE
Changed Cache so it works with current JRuby

### DIFF
--- a/ext/mixology/MixologyService.java
+++ b/ext/mixology/MixologyService.java
@@ -34,6 +34,7 @@ public class MixologyService implements BasicLibraryService {
 						  if(module.getSuperClass() != null && module.getSuperClass() instanceof IncludedModuleWrapper) 
 								remove_nested_module(klass.getSuperClass(), module);
 									setSuperClass(klass, klass.getSuperClass().getSuperClass());
+                  clearCacheMap(klass, module);
 						}
         }
 
@@ -66,6 +67,7 @@ public class MixologyService implements BasicLibraryService {
 		  }
 
 				add_module(klass, module);
+        clearCache(klass, klass.getSuperClass());
 
 				return recv;
 		}
@@ -78,6 +80,8 @@ public class MixologyService implements BasicLibraryService {
 				IncludedModuleWrapper includedKlass = new IncludedModuleWrapper(klass.getRuntime(), klass.getSuperClass(), module);
 				
         setSuperClass(klass, includedKlass);
+
+        clearCache(klass, klass.getSuperClass());
     }
 
 		protected synchronized static void remove_nested_module(RubyClass klass, RubyModule include_class) 
@@ -104,4 +108,11 @@ public class MixologyService implements BasicLibraryService {
 				method.invoke(klass, superClassArg);
 		}
 
+    protected static void clearCache(RubyModule klass, RubyModule module) {
+        List<String> methodNames = new ArrayList<String>(module.getMethods().keySet());
+        for (Iterator iter = methodNames.iterator(); iter.hasNext();) {
+            String methodName = (String) iter.next();
+            klass.getRuntime().getConstantCacheMap().remove(klass.searchMethod(methodName));
+        }
+    }
 }

--- a/ext/mixology/MixologyService.java
+++ b/ext/mixology/MixologyService.java
@@ -34,7 +34,6 @@ public class MixologyService implements BasicLibraryService {
 						  if(module.getSuperClass() != null && module.getSuperClass() instanceof IncludedModuleWrapper) 
 								remove_nested_module(klass.getSuperClass(), module);
 									setSuperClass(klass, klass.getSuperClass().getSuperClass());
-									clearCache(klass, module);	
 						}
         }
 
@@ -67,7 +66,6 @@ public class MixologyService implements BasicLibraryService {
 		  }
 
 				add_module(klass, module);
-				clearCache(klass, klass.getSuperClass());	
 
 				return recv;
 		}
@@ -80,8 +78,6 @@ public class MixologyService implements BasicLibraryService {
 				IncludedModuleWrapper includedKlass = new IncludedModuleWrapper(klass.getRuntime(), klass.getSuperClass(), module);
 				
         setSuperClass(klass, includedKlass);
-
-				clearCache(klass, klass.getSuperClass());	
     }
 
 		protected synchronized static void remove_nested_module(RubyClass klass, RubyModule include_class) 
@@ -108,12 +104,4 @@ public class MixologyService implements BasicLibraryService {
 				method.invoke(klass, superClassArg);
 		}
 
-		protected static void clearCache(RubyModule klass, RubyModule module) {
-			List<String> methodNames = new ArrayList<String>(module.getMethods().keySet());
-      for (Iterator iter = methodNames.iterator();
-      	iter.hasNext();) {
-        String methodName = (String) iter.next();
-        // klass.getRuntime().getCacheMap().remove(klass.searchMethod(methodName));
-      }
-		}
 }

--- a/ext/mixology/MixologyService.java
+++ b/ext/mixology/MixologyService.java
@@ -113,7 +113,7 @@ public class MixologyService implements BasicLibraryService {
       for (Iterator iter = methodNames.iterator();
       	iter.hasNext();) {
         String methodName = (String) iter.next();
-        klass.getRuntime().getCacheMap().remove(klass.searchMethod(methodName));
+        // klass.getRuntime().getCacheMap().remove(klass.searchMethod(methodName));
       }
 		}
 }

--- a/test/mixology_test.rb
+++ b/test/mixology_test.rb
@@ -64,7 +64,7 @@ class MixologyTest < Test::Unit::TestCase
     mixin = Module.new
     object = Object.new
     object.mixin mixin
-    assert_equal [mixin, Mixology, PP::ObjectMixin, Kernel], (class << object; self; end).included_modules
+    assert_equal [mixin, Mixology, PP::ObjectMixin, Rake::DeprecatedObjectDSL, Kernel], (class << object; self; end).included_modules
   end
   
   def test_included_modules_after_unmix
@@ -72,7 +72,7 @@ class MixologyTest < Test::Unit::TestCase
     object = Object.new
     object.mixin mixin
     object.unmix mixin
-    assert_equal [Mixology, PP::ObjectMixin, Kernel], (class << object; self; end).included_modules
+    assert_equal [Mixology, PP::ObjectMixin, Rake::DeprecatedObjectDSL, Kernel], (class << object; self; end).included_modules
   end
   
   def test_included_modules_after_remix
@@ -81,9 +81,9 @@ class MixologyTest < Test::Unit::TestCase
     object = Object.new
     object.mixin mixin_one
     object.mixin mixin_two
-    assert_equal [mixin_two, mixin_one, Mixology, PP::ObjectMixin, Kernel], (class << object; self; end).included_modules
+    assert_equal [mixin_two, mixin_one, Mixology, PP::ObjectMixin, Rake::DeprecatedObjectDSL, Kernel], (class << object; self; end).included_modules
     object.mixin mixin_one
-    assert_equal [mixin_one, mixin_two, Mixology, PP::ObjectMixin, Kernel], (class << object; self; end).included_modules
+    assert_equal [mixin_one, mixin_two, Mixology, PP::ObjectMixin, Rake::DeprecatedObjectDSL, Kernel], (class << object; self; end).included_modules
   end
   
   def test_mixin_returns_object
@@ -107,7 +107,7 @@ class MixologyTest < Test::Unit::TestCase
     mixin = Module.new { include nested_module }
     object = Object.new
     object.mixin mixin
-    assert_equal [mixin, nested_module, Mixology, PP::ObjectMixin, Kernel], (class << object; self; end).included_modules
+    assert_equal [mixin, nested_module, Mixology, PP::ObjectMixin, Rake::DeprecatedObjectDSL, Kernel], (class << object; self; end).included_modules
   end
 
   def test_nested_modules_are_mixedin_deeply
@@ -120,7 +120,7 @@ class MixologyTest < Test::Unit::TestCase
     mixin = Module.new { include nested_module }
     object = Object.new
     object.mixin mixin
-    assert_equal [mixin, nested_module, nested_module_penultimate, nested_module_ultimate, Mixology, PP::ObjectMixin, Kernel], (class << object; self; end).included_modules
+    assert_equal [mixin, nested_module, nested_module_penultimate, nested_module_ultimate, Mixology, PP::ObjectMixin, Rake::DeprecatedObjectDSL, Kernel], (class << object; self; end).included_modules
   end
    
   def test_nested_modules_are_mixedin_even_if_already_mixed_in
@@ -132,7 +132,7 @@ class MixologyTest < Test::Unit::TestCase
     object = Object.new
     object.mixin nested_module
     object.mixin mixin
-    assert_equal [mixin, nested_module, nested_module, Mixology, PP::ObjectMixin, Kernel], (class << object; self; end).included_modules
+    assert_equal [mixin, nested_module, nested_module, Mixology, PP::ObjectMixin, Rake::DeprecatedObjectDSL, Kernel], (class << object; self; end).included_modules
   end
   
   def test_module_is_not_unmixed_if_it_is_outside_nested_chain
@@ -142,7 +142,7 @@ class MixologyTest < Test::Unit::TestCase
     object.mixin nested_module
     object.mixin mixin
     object.unmix mixin
-    assert_equal [nested_module, Mixology, PP::ObjectMixin, Kernel], (class << object; self; end).included_modules
+    assert_equal [nested_module, Mixology, PP::ObjectMixin, Rake::DeprecatedObjectDSL, Kernel], (class << object; self; end).included_modules
   end
   
   def test_nested_modules_are_unmixed
@@ -151,7 +151,7 @@ class MixologyTest < Test::Unit::TestCase
     object = Object.new
     object.mixin mixin
     object.unmix mixin
-    assert_equal [Mixology, PP::ObjectMixin, Kernel], (class << object; self; end).included_modules
+    assert_equal [Mixology, PP::ObjectMixin, Rake::DeprecatedObjectDSL, Kernel], (class << object; self; end).included_modules
   end
   
   def test_nested_modules_are_unmixed_deeply
@@ -162,7 +162,7 @@ class MixologyTest < Test::Unit::TestCase
     object = Object.new
     object.mixin mixin
     object.unmix mixin
-    assert_equal [Mixology, PP::ObjectMixin, Kernel], (class << object; self; end).included_modules
+    assert_equal [Mixology, PP::ObjectMixin, Rake::DeprecatedObjectDSL, Kernel], (class << object; self; end).included_modules
   end
 
   def test_unrelated_modules_are_not_unmixed
@@ -173,7 +173,7 @@ class MixologyTest < Test::Unit::TestCase
     object.mixin unrelated
     object.mixin mixin
     object.unmix mixin
-    assert_equal [unrelated, Mixology, PP::ObjectMixin, Kernel], (class << object; self; end).included_modules
+    assert_equal [unrelated, Mixology, PP::ObjectMixin, Rake::DeprecatedObjectDSL, Kernel], (class << object; self; end).included_modules
   end
   
   def rubinius?


### PR DESCRIPTION
getCacheMap has been replaced with getConstantCacheMap in JRuby in 2008.  This patch will cause the gem to work properly with JRuby versions 1.2 and greater.
